### PR TITLE
refactor: update macOS network connection handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,12 +83,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,29 +101,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.9.1",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
- "shlex",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -164,12 +138,6 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bytes"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -264,7 +232,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -619,7 +587,7 @@ version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78a09b56be5adbcad5aa1197371688dc6bb249a26da3bca2011ee2fb987ebfb"
 dependencies = [
- "bindgen 0.70.1",
+ "bindgen",
  "errno",
  "libc",
 ]
@@ -695,73 +663,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "netlink-packet-core"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
-dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-sock-diag"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a495cb1de50560a7cd12fdcf023db70eec00e340df81be31cedbbfd4aadd6b76"
-dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
- "libc",
- "netlink-packet-core",
- "netlink-packet-utils",
- "smallvec",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "netlink-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
-dependencies = [
- "bytes",
- "libc",
- "log",
-]
-
-[[package]]
-name = "netstat2"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6422b6a8c7635e8a82323e4cdf07a90e91901e07f4c1f0f3a245d54b4637e55c"
-dependencies = [
- "bindgen 0.71.1",
- "bitflags 2.9.1",
- "byteorder",
- "netlink-packet-core",
- "netlink-packet-sock-diag",
- "netlink-packet-utils",
- "netlink-sys",
- "num-derive",
- "num-traits",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "newline-converter"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,17 +691,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -848,12 +738,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pest"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,7 +768,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -895,16 +779,6 @@ checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
  "pest",
  "sha2",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
-dependencies = [
- "proc-macro2",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -985,12 +859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustix"
 version = "0.36.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,7 +921,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1129,8 +997,8 @@ dependencies = [
  "clap_complete",
  "handlebars",
  "inquire",
+ "libc",
  "libproc",
- "netstat2",
  "nix",
  "procfs",
  "serde",
@@ -1144,17 +1012,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -1217,7 +1074,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1228,7 +1085,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1301,7 +1158,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1323,7 +1180,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1380,7 +1237,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1391,7 +1248,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ nix = {version = "0.30.1", features = ["process", "signal"]}
 procfs = "0.15.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-netstat2 = "0.11.1"
 libproc = "0.14.10"
+libc = "0.2"

--- a/src/connections/macos.rs
+++ b/src/connections/macos.rs
@@ -1,119 +1,469 @@
-use libproc::libproc::proc_pid;
-use netstat2::{
-    get_sockets_info, AddressFamilyFlags, ProtocolFlags, ProtocolSocketInfo as NetstatSocketInfo,
-};
 use std::collections::HashSet;
+use std::convert::TryInto;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use crate::schemas::{Connection, FilterOptions};
+use libc;
+use libproc::bsd_info::BSDInfo;
+use libproc::file_info::{pidfdinfo, ListFDs, ProcFDType};
+use libproc::net_info::{SocketFDInfo, TcpSIState};
+use libproc::proc_pid::{listpidinfo, pidinfo};
+use libproc::processes::{pids_by_type, ProcFilter};
 
 use crate::connections::common::{filter_out_connection, get_address_type};
+use crate::schemas::{Connection, FilterOptions};
 
-/// Gets the process name for a given PID on macOS
-fn get_process_name(pid: i32) -> String {
-    match proc_pid::name(pid) {
-        Ok(name) => name,
-        Err(_) => "-".to_string(),
+/// Convert TcpSIState to connection state string
+fn get_tcp_state(status: TcpSIState) -> String {
+    // Match the TcpSIState enum to appropriate string representations
+    match status {
+        TcpSIState::Established => "established".to_string(),
+        TcpSIState::Listen => "listening".to_string(),
+        TcpSIState::SynSent => "syn_sent".to_string(),
+        TcpSIState::SynReceived => "syn_received".to_string(),
+        TcpSIState::FinWait1 => "fin_wait1".to_string(),
+        TcpSIState::FinWait2 => "fin_wait2".to_string(),
+        TcpSIState::TimeWait => "time_wait".to_string(),
+        TcpSIState::Closed => "closed".to_string(),
+        TcpSIState::CloseWait => "close_wait".to_string(),
+        TcpSIState::LastAck => "last_ack".to_string(),
+        TcpSIState::Closing => "closing".to_string(),
+        _ => "unknown".to_string(),
     }
 }
 
-/// Gets network connection information on macOS using the netstat2 library.
+/// Create a connection object from TCP socket information
 ///
 /// # Arguments
-/// * `filter_options`: The filter options provided by the user.
+/// * `pid`: Process ID
+/// * `program`: Process name
+/// * `socket_info`: Socket information
+/// * `exclude_ipv6`: Whether to exclude IPv6 connections
 ///
 /// # Returns
-/// All processed and filtered TCP/UDP connections as a `Connection` struct in a vector.
+/// A Connection object if the socket is a TCP socket, otherwise None
+fn tcp_socket_to_connection(
+    pid: i32,
+    program: String,
+    socket_info: &SocketFDInfo,
+    exclude_ipv6: bool,
+) -> Option<Connection> {
+    unsafe {
+        // Check if this is a TCP socket of the appropriate family (IPv4 or IPv6)
+        match socket_info.psi.soi_family {
+            libc::AF_INET if socket_info.psi.soi_protocol == libc::IPPROTO_TCP => {
+                let tcp_info = socket_info.psi.soi_proto.pri_tcp;
+
+                // Get the local port number, handling byte order conversion
+                // Swap bytes to convert from network byte order to host byte order
+                let local_port = (((tcp_info.tcpsi_ini.insi_lport >> 8) & 0xff)
+                    | ((tcp_info.tcpsi_ini.insi_lport << 8) & 0xff00))
+                    .to_string();
+
+                // Get IPv4 address - convert in_addr to u32
+                let in_addr = tcp_info.tcpsi_ini.insi_faddr.ina_46.i46a_addr4.s_addr;
+                let ip_addr = IpAddr::V4(Ipv4Addr::from(u32::from_be(in_addr)));
+
+                // Extract readable form of address and port
+                let remote_addr = format!("{}", ip_addr);
+
+                // Get the remote port number, handling byte order conversion
+                let remote_port = (((tcp_info.tcpsi_ini.insi_fport >> 8) & 0xff)
+                    | ((tcp_info.tcpsi_ini.insi_fport << 8) & 0xff00))
+                    .to_string();
+
+                // Get the connection state
+                let state = get_tcp_state(tcp_info.tcpsi_state.into());
+
+                // Calculate address type (private, local, etc.)
+                let addr_type = get_address_type(&remote_addr);
+
+                // Return a new Connection object
+                Some(Connection {
+                    proto: "tcp".to_string(),
+                    local_port,
+                    remote_address: remote_addr,
+                    remote_port,
+                    program,
+                    pid: pid.to_string(),
+                    state,
+                    address_type: addr_type,
+                    ipvx_raw: ip_addr,
+                })
+            }
+            libc::AF_INET6
+                if socket_info.psi.soi_protocol == libc::IPPROTO_TCP && !exclude_ipv6 =>
+            {
+                let tcp_info = socket_info.psi.soi_proto.pri_tcp;
+
+                // Get the local port number, handling byte order conversion
+                let local_port = (((tcp_info.tcpsi_ini.insi_lport >> 8) & 0xff)
+                    | ((tcp_info.tcpsi_ini.insi_lport << 8) & 0xff00))
+                    .to_string();
+
+                // Extract IPv6 address
+                let addr = tcp_info.tcpsi_ini.insi_faddr.ina_6;
+
+                // Build IPv6 address by combining byte pairs into 16-bit segments
+                let segments = [
+                    ((addr.s6_addr[0] as u16) << 8) | (addr.s6_addr[1] as u16),
+                    ((addr.s6_addr[2] as u16) << 8) | (addr.s6_addr[3] as u16),
+                    ((addr.s6_addr[4] as u16) << 8) | (addr.s6_addr[5] as u16),
+                    ((addr.s6_addr[6] as u16) << 8) | (addr.s6_addr[7] as u16),
+                    ((addr.s6_addr[8] as u16) << 8) | (addr.s6_addr[9] as u16),
+                    ((addr.s6_addr[10] as u16) << 8) | (addr.s6_addr[11] as u16),
+                    ((addr.s6_addr[12] as u16) << 8) | (addr.s6_addr[13] as u16),
+                    ((addr.s6_addr[14] as u16) << 8) | (addr.s6_addr[15] as u16),
+                ];
+
+                // Create IPv6 address from segments
+                let ip_addr = IpAddr::V6(Ipv6Addr::from(segments));
+
+                // Extract readable form of address
+                let remote_addr = format!("{}", ip_addr);
+
+                // Get the remote port number, handling byte order conversion
+                let remote_port = (((tcp_info.tcpsi_ini.insi_fport >> 8) & 0xff)
+                    | ((tcp_info.tcpsi_ini.insi_fport << 8) & 0xff00))
+                    .to_string();
+
+                // Get the connection state
+                let state = get_tcp_state(tcp_info.tcpsi_state.into());
+
+                // Calculate address type (private, local, etc.)
+                let addr_type = get_address_type(&remote_addr);
+
+                // Return a new Connection object
+                Some(Connection {
+                    proto: "tcp".to_string(),
+                    local_port,
+                    remote_address: remote_addr,
+                    remote_port,
+                    program,
+                    pid: pid.to_string(),
+                    state,
+                    address_type: addr_type,
+                    ipvx_raw: ip_addr,
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Create a connection object from UDP socket information
+///
+/// # Arguments
+/// * `pid`: Process ID
+/// * `program`: Process name
+/// * `socket_info`: Socket information
+/// * `exclude_ipv6`: Whether to exclude IPv6 connections
+///
+/// # Returns
+/// A Connection object if the socket is a UDP socket, otherwise None
+fn udp_socket_to_connection(
+    pid: i32,
+    program: String,
+    socket_info: &SocketFDInfo,
+    exclude_ipv6: bool,
+) -> Option<Connection> {
+    unsafe {
+        // Check if this is a UDP socket of the appropriate family (IPv4 or IPv6)
+        match socket_info.psi.soi_family {
+            libc::AF_INET if socket_info.psi.soi_protocol == libc::IPPROTO_UDP => {
+                let udp_info = socket_info.psi.soi_proto.pri_in;
+
+                // Get the local port number, handling byte order conversion
+                let local_port = (((udp_info.insi_lport >> 8) & 0xff)
+                    | ((udp_info.insi_lport << 8) & 0xff00))
+                    .to_string();
+
+                // Get IPv4 address - convert in_addr to u32
+                let in_addr = udp_info.insi_faddr.ina_46.i46a_addr4.s_addr;
+                let ip_addr = IpAddr::V4(Ipv4Addr::from(u32::from_be(in_addr)));
+
+                // Extract readable form of address and port
+                let remote_addr = format!("{}", ip_addr);
+
+                // Get the remote port number, handling byte order conversion
+                let remote_port = (((udp_info.insi_fport >> 8) & 0xff)
+                    | ((udp_info.insi_fport << 8) & 0xff00))
+                    .to_string();
+
+                // For UDP, we infer state based on remote address and port
+                // If both are 0, it's a listening socket, otherwise established
+                let state = if remote_addr == "0.0.0.0" && remote_port == "0" {
+                    "listening".to_string()
+                } else {
+                    "established".to_string()
+                };
+
+                // Calculate address type (private, local, etc.)
+                let addr_type = get_address_type(&remote_addr);
+
+                // Return a new Connection object
+                Some(Connection {
+                    proto: "udp".to_string(),
+                    local_port,
+                    remote_address: remote_addr,
+                    remote_port,
+                    program,
+                    pid: pid.to_string(),
+                    state,
+                    address_type: addr_type,
+                    ipvx_raw: ip_addr,
+                })
+            }
+            libc::AF_INET6
+                if socket_info.psi.soi_protocol == libc::IPPROTO_UDP && !exclude_ipv6 =>
+            {
+                let udp_info = socket_info.psi.soi_proto.pri_in;
+
+                // Get the local port number, handling byte order conversion
+                let local_port = (((udp_info.insi_lport >> 8) & 0xff)
+                    | ((udp_info.insi_lport << 8) & 0xff00))
+                    .to_string();
+
+                // Extract IPv6 address
+                let addr = udp_info.insi_faddr.ina_6;
+
+                // Build IPv6 address by combining byte pairs into 16-bit segments
+                let segments = [
+                    ((addr.s6_addr[0] as u16) << 8) | (addr.s6_addr[1] as u16),
+                    ((addr.s6_addr[2] as u16) << 8) | (addr.s6_addr[3] as u16),
+                    ((addr.s6_addr[4] as u16) << 8) | (addr.s6_addr[5] as u16),
+                    ((addr.s6_addr[6] as u16) << 8) | (addr.s6_addr[7] as u16),
+                    ((addr.s6_addr[8] as u16) << 8) | (addr.s6_addr[9] as u16),
+                    ((addr.s6_addr[10] as u16) << 8) | (addr.s6_addr[11] as u16),
+                    ((addr.s6_addr[12] as u16) << 8) | (addr.s6_addr[13] as u16),
+                    ((addr.s6_addr[14] as u16) << 8) | (addr.s6_addr[15] as u16),
+                ];
+
+                // Create IPv6 address from segments
+                let ip_addr = IpAddr::V6(Ipv6Addr::from(segments));
+
+                // Extract readable form of address
+                let remote_addr = format!("{}", ip_addr);
+
+                // Get the remote port number, handling byte order conversion
+                let remote_port = (((udp_info.insi_fport >> 8) & 0xff)
+                    | ((udp_info.insi_fport << 8) & 0xff00))
+                    .to_string();
+
+                // For UDP IPv6, we infer state based on remote address and port
+                // If using the IPv6 unspecified address (::) and port 0, it's a listening socket
+                let state = if remote_addr == "::" && remote_port == "0" {
+                    "listening".to_string()
+                } else {
+                    "established".to_string()
+                };
+
+                // Calculate address type (private, local, etc.)
+                let addr_type = get_address_type(&remote_addr);
+
+                // Return a new Connection object
+                Some(Connection {
+                    proto: "udp".to_string(),
+                    local_port,
+                    remote_address: remote_addr,
+                    remote_port,
+                    program,
+                    pid: pid.to_string(),
+                    state,
+                    address_type: addr_type,
+                    ipvx_raw: ip_addr,
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Create a unique connection identifier for deduplication
+///
+/// # Arguments
+/// * `conn`: Connection object
+///
+/// # Returns
+/// A unique connection identifier
+fn create_connection_key(conn: &Connection) -> String {
+    // Format: protocol:local_port:remote_address:remote_port.state:pid
+    format!(
+        "{}:{}:{}:{}.{}:{}",
+        conn.proto, conn.local_port, conn.remote_address, conn.remote_port, conn.state, conn.pid
+    )
+}
+
+/// Get process name from its PID
+///
+/// # Arguments
+/// * `pid`: Process ID
+///
+/// # Returns
+/// The process name
+fn get_process_name(pid: i32) -> String {
+    // Try to get the process name, return "unknown[pid]" if it fails
+    match libproc::proc_pid::name(pid) {
+        Ok(name) => name,
+        Err(_) => format!("unknown[{}]", pid),
+    }
+}
+
+/// Get network connection information on macOS using the libproc library
+///
+/// # Arguments
+/// * `filter_options`: User-provided filter options
+///
+/// # Returns
+/// All processed and filtered TCP/UDP connections as Vec<Connection>
 pub fn get_connections(filter_options: &FilterOptions) -> Vec<Connection> {
-    // Determine which address families to include
-    let mut af_flags = AddressFamilyFlags::empty();
-    if !filter_options.exclude_ipv6 {
-        af_flags |= AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6;
-    } else {
-        af_flags |= AddressFamilyFlags::IPV4;
+    // Return early if no protocols are requested
+    if !filter_options.by_proto.tcp && !filter_options.by_proto.udp {
+        return Vec::new();
     }
 
-    // Determine which protocols to include
-    let mut proto_flags = ProtocolFlags::empty();
-    if filter_options.by_proto.tcp {
-        proto_flags |= ProtocolFlags::TCP;
-    }
-    if filter_options.by_proto.udp {
-        proto_flags |= ProtocolFlags::UDP;
-    }
-
-    // Get the socket information using netstat2
-    let sockets_info = match get_sockets_info(af_flags, proto_flags) {
-        Ok(sockets) => sockets,
+    // Get all process PIDs
+    let pids = match pids_by_type(ProcFilter::All) {
+        Ok(pids) => pids,
         Err(_) => return Vec::new(),
     };
 
-    // Temporary storage for connection features, for deduplication
+    // HashSet to track seen connections for deduplication
     let mut seen_connections = HashSet::new();
+    let mut results = Vec::new();
 
-    // Convert the socket information to our Connection type
-    sockets_info
-        .iter()
-        .filter_map(|si| {
-            let (proto, local_port, remote_address, remote_port, state) =
-                match &si.protocol_socket_info {
-                    NetstatSocketInfo::Tcp(tcp_si) => {
-                        let state = format!("{}", tcp_si.state).to_ascii_lowercase();
-                        (
-                            "tcp".to_string(),
-                            tcp_si.local_port.to_string(),
-                            tcp_si.remote_addr.to_string(),
-                            tcp_si.remote_port.to_string(),
-                            state,
-                        )
-                    }
-                    NetstatSocketInfo::Udp(udp_si) => (
-                        "udp".to_string(),
-                        udp_si.local_port.to_string(),
-                        "0.0.0.0".to_string(),
-                        "-".to_string(),
-                        "-".to_string(),
-                    ),
-                };
+    // Iterate through all processes
+    for &pid in &pids {
+        // Skip kernel process
+        if pid == 0 {
+            continue;
+        }
 
-            // Get program and PID info
-            let (program, pid) = if let Some(first_pid) = si.associated_pids.first() {
-                // Get process name
-                let proc_name = get_process_name(*first_pid as i32);
-                (proc_name, first_pid.to_string())
-            } else {
-                ("-".to_string(), "-".to_string())
-            };
+        // Process connections for this PID
+        process_pid_connections(pid, filter_options, &mut seen_connections, &mut results);
+    }
 
-            // Create a unique key for deduplication
-            let connection_key = format!(
-                "{}:{}:{}:{}.{}:{}",
-                proto, local_port, remote_address, remote_port, state, pid
+    results
+}
+
+/// Process connections for a single PID
+///
+/// # Arguments
+/// * `pid`: Process ID
+/// * `filter_options`: User-provided filter options
+/// * `seen_connections`: HashSet to track seen connections for deduplication
+/// * `results`: Vector to store the results
+fn process_pid_connections(
+    pid: u32,
+    filter_options: &FilterOptions,
+    seen_connections: &mut HashSet<String>,
+    results: &mut Vec<Connection>,
+) {
+    // Convert u32 type pid to i32 for API calls
+    let i_pid: i32 = match pid.try_into() {
+        Ok(p) => p,
+        Err(_) => return, // Skip pids that can't be converted
+    };
+
+    // Get process name
+    let process_name = get_process_name(i_pid);
+
+    // Get BSD info to determine the number of file descriptors
+    let bsd_info = match pidinfo::<BSDInfo>(i_pid, 0) {
+        Ok(info) => info,
+        Err(_) => return,
+    };
+
+    // Get the list of file descriptors for the process
+    let fds = match listpidinfo::<ListFDs>(i_pid, bsd_info.pbi_nfiles as usize) {
+        Ok(fds) => fds,
+        Err(_) => return,
+    };
+
+    // Process each file descriptor
+    for fd in fds {
+        // Only process socket type file descriptors
+        if let ProcFDType::Socket = fd.proc_fdtype.into() {
+            process_socket_fd(
+                i_pid,
+                fd.proc_fd,
+                &process_name,
+                filter_options,
+                seen_connections,
+                results,
             );
+        }
+    }
+}
 
-            // If the connection has already been processed, skip it
-            if !seen_connections.insert(connection_key) {
-                return None;
-            }
+/// Process a socket file descriptor
+///
+/// # Arguments
+/// * `pid`: Process ID
+/// * `fd`: File descriptor
+/// * `process_name`: Process name
+/// * `filter_options`: User-provided filter options
+fn process_socket_fd(
+    pid: i32,
+    fd: i32,
+    process_name: &str,
+    filter_options: &FilterOptions,
+    seen_connections: &mut HashSet<String>,
+    results: &mut Vec<Connection>,
+) {
+    // Get detailed socket information
+    let socket_info = match pidfdinfo::<SocketFDInfo>(pid, fd) {
+        Ok(info) => info,
+        Err(_) => return,
+    };
 
-            // Create our connection data structure
-            let conn = Connection {
-                proto,
-                local_port,
-                remote_address: remote_address.clone(),
-                remote_port,
-                program,
-                pid,
-                state,
-                address_type: get_address_type(&remote_address),
-                ipvx_raw: si.local_addr(),
-            };
+    // Process TCP connections if requested
+    if filter_options.by_proto.tcp && socket_info.psi.soi_protocol == libc::IPPROTO_TCP {
+        if let Some(conn) = tcp_socket_to_connection(
+            pid,
+            process_name.to_string(),
+            &socket_info,
+            filter_options.exclude_ipv6,
+        ) {
+            add_connection_if_new(conn, filter_options, seen_connections, results);
+        }
+    }
 
-            // Filter connections based on the provided options
-            if filter_out_connection(&conn, filter_options) {
-                None
-            } else {
-                Some(conn)
-            }
-        })
-        .collect()
+    // Process UDP connections if requested
+    if filter_options.by_proto.udp && socket_info.psi.soi_protocol == libc::IPPROTO_UDP {
+        if let Some(conn) = udp_socket_to_connection(
+            pid,
+            process_name.to_string(),
+            &socket_info,
+            filter_options.exclude_ipv6,
+        ) {
+            add_connection_if_new(conn, filter_options, seen_connections, results);
+        }
+    }
+}
+
+/// Add a connection to the results if it's new and passes filters
+///
+/// # Arguments
+/// * `conn`: Connection object
+/// * `filter_options`: User-provided filter options
+/// * `seen_connections`: HashSet to track seen connections for deduplication
+/// * `results`: Vector to store the results
+fn add_connection_if_new(
+    conn: Connection,
+    filter_options: &FilterOptions,
+    seen_connections: &mut HashSet<String>,
+    results: &mut Vec<Connection>,
+) {
+    // Create a unique key for deduplication
+    let connection_key = create_connection_key(&conn);
+
+    // Skip if we've seen this connection before
+    if !seen_connections.insert(connection_key) {
+        return;
+    }
+
+    // Add to results if it passes the filter
+    if !filter_out_connection(&conn, filter_options) {
+        results.push(conn);
+    }
 }


### PR DESCRIPTION
- replace netstat2 with libproc for network connection retrieval
- implement connection deduplication using a HashSet
- update connection state handling for TCP and UDP sockets
- improve error handling and process name retrieval